### PR TITLE
fix(ConfigStoreClient): Unset searchConfig.toBlock after update()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.23.7",
+  "version": "0.23.8",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -489,6 +489,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     this.hasLatestConfigStoreVersion = this.hasValidConfigStoreVersionForTimestamp();
     this.latestBlockSearched = result.searchEndBlock;
     this.firstBlockToSearch = result.searchEndBlock + 1; // Next iteration should start off from where this one ended.
+    this.eventSearchConfig.toBlock = undefined; // Caller can re-set on subsequent updates if necessary
     this.chainId = this.chainId ?? chainId; // Update on the first run only.
     this.isUpdated = true;
 


### PR DESCRIPTION
Otherwise any subsequent update() calls will resolve that fromBlock > toBlock, and no update will occur.