### PR TITLE
chore(version): bump to 0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.23.13",
+  "version": "0.24.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [


### PR DESCRIPTION
The `relayFeeCalculator` changes are breaking. We should do a minor bump.